### PR TITLE
Hide Console on Windows

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
 use app::{
     exports::{
         self,


### PR DESCRIPTION
Hides the Console on Windows on production builds.

Fixes #89 