### PR TITLE
Disable macOS actions release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
-            triplet: x64-osx
           - platform: windows-latest
             triplet: x64-windows-static-md
           - platform: ubuntu-latest


### PR DESCRIPTION
This will now be done locally to resolve issues with signing and notorization.